### PR TITLE
Update fs_extra(1.3) to ensure compilability in the future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ include = ["src/", "example_files", "LICENSE-*", "README.md", "COPYRIGHT"]
 
 [dependencies]
 anyhow = "1.0"
-fs_extra = "1.2"
+fs_extra = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copy_to_output"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Hi prenwyn,

I used copy_to_output 2.0 and got the following message from cargo: 

> warning: the following packages contain code that will be rejected by a future version of Rust: fs_extra v1.2.0

Updating fs_extra to version 1.3, does not have this warning. This PR updates this dependeny and increments the version of copy_to_output to 2.0.1.
