### PR TITLE
Support cross compilation / CompileKind::target inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ include = ["src/", "example_files", "LICENSE-*", "README.md", "COPYRIGHT"]
 [dependencies]
 anyhow = "1.0"
 fs_extra = "1.3"
+build-target = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,37 @@
+use std::result::Result::Ok;
+use std::env;
 use fs_extra::copy_items;
 use fs_extra::dir::CopyOptions;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use anyhow::*;
 
 pub fn copy_to_output(path: &str, build_type: &str) -> Result<()> {
-    let mut options = CopyOptions::new();
-    let mut from_path = Vec::new();
-    let out_path = format!("target/{}", build_type);
+    let mut out_path = PathBuf::new();
+    out_path.push("target");
+
+    // This is a hack, ideally we would plug into https://docs.rs/cargo/latest/cargo/core/compiler/enum.CompileKind.html
+    // However, since the path follows predictable rules https://doc.rust-lang.org/cargo/guide/build-cache.html
+    // we can just check our parent path for the pattern target/{triple}/{profile}.
+    // If it is present, we know CompileKind::Target was used, otherwise CompileKind::Host was used.
+    // Best effort since the existing tests aren't intended to be run in a real build this won't exist.
+    // Unclear if that also means people in the wild are using the crate similarly, so avoiding any risk of break.
+    if let Ok(triple) = build_target::target_triple() {
+        if let Some(out_dir) = env::var_os("OUT_DIR") {
+            if let Some(out_dir) = out_dir.to_str() {
+                if out_dir.contains(&format!("target{}{}", std::path::MAIN_SEPARATOR, triple)) {
+                    out_path.push(triple);
+                }
+            }
+        }
+    }
+
+    out_path.push(build_type);
 
     // Overwrite existing files with same name
+    let mut options = CopyOptions::new();
     options.overwrite = true;
 
+    let mut from_path = Vec::new();
     from_path.push(path);
     copy_items(&from_path, &out_path, &options)?;
 


### PR DESCRIPTION
Inspect `env:OUT_DIR` to determine `CompileKind`, injecting target into the output path if found.

Originally, I had it working with get_project_root (see #3 discussion), but when copying that code over I noticed that it will cause the tests to fail since the tests aren't recreating a full cargo build environment.

Not sure if that's the direction @prenwyn wants to go or not, so what I've changed it to be best effort to keep the tests happy. The ideal solution in my opinion would be to revamp the testing to run `cargo build` on sample project(s) to test the various setups.